### PR TITLE
Make tests work on a new venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Alternatively, you may use the [videofront-client](https://github.com/openfun/vi
 Install test and contrib requirements:
 
     pip install -r requirements/tests.txt
-    pip install -r requirements/aws.txt
 
 Run unit tests:
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,3 +4,4 @@
 mock==2.0.0
 coverage
 factory-boy==2.7.0
+fake-factory==0.7.4


### PR DESCRIPTION
The main update is to add a pinned version of `fake-factory`. 

Here is the commit message (the second one in this PR):

```Force fake-factory version

In `factory-boy==2.7.0`, there is this requirement `fake-factory>=0.5.0`

But the last version of `fake-factory`, which is `9999.9.9`, is just
telling that this lib does not exist anymore, and it is this version
that is installed on a fresh new venv.

So forcing the version of `fake-factory` to be the last know
working/existing version is the minimal update to make it work.
```